### PR TITLE
Add minimal Airflow control plane Docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build-webserver build-scheduler build-triggerer build-control-plane
+
+build-webserver:
+	docker build -t airbridge-webserver:3.0.4 -f control-plane/webserver/Dockerfile control-plane
+
+build-scheduler:
+	docker build -t airbridge-scheduler:3.0.4 -f control-plane/scheduler/Dockerfile control-plane
+
+build-triggerer:
+	docker build -t airbridge-triggerer:3.0.4 -f control-plane/triggerer/Dockerfile control-plane
+
+build-control-plane: build-webserver build-scheduler build-triggerer

--- a/control-plane/build.sh
+++ b/control-plane/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+docker build -t airbridge-webserver:3.0.4 -f "$ROOT_DIR/webserver/Dockerfile" "$ROOT_DIR"
+docker build -t airbridge-scheduler:3.0.4 -f "$ROOT_DIR/scheduler/Dockerfile" "$ROOT_DIR"
+docker build -t airbridge-triggerer:3.0.4 -f "$ROOT_DIR/triggerer/Dockerfile" "$ROOT_DIR"

--- a/control-plane/scheduler/Dockerfile
+++ b/control-plane/scheduler/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+ENV AIRFLOW_HOME=/opt/airflow \
+    AIRFLOW_VERSION=3.0.4 \
+    PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 50000 airflow \
+    && useradd --uid 50000 --gid airflow --home-dir ${AIRFLOW_HOME} --create-home airflow
+
+USER airflow
+WORKDIR ${AIRFLOW_HOME}
+
+RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
+
+COPY ../scripts/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD airflow jobs check --job-type SchedulerJob || exit 1
+
+CMD ["airflow", "scheduler"]

--- a/control-plane/scripts/entrypoint.sh
+++ b/control-plane/scripts/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${AIRFLOW_HOME:=/opt/airflow}"
+
+# Initialize database if needed
+airflow db migrate
+
+# Execute the container's main process
+exec "$@"

--- a/control-plane/triggerer/Dockerfile
+++ b/control-plane/triggerer/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.11-slim
+
+ENV AIRFLOW_HOME=/opt/airflow \
+    AIRFLOW_VERSION=3.0.4 \
+    PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 50000 airflow \
+    && useradd --uid 50000 --gid airflow --home-dir ${AIRFLOW_HOME} --create-home airflow
+
+USER airflow
+WORKDIR ${AIRFLOW_HOME}
+
+RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
+
+COPY ../scripts/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD airflow jobs check --job-type TriggererJob || exit 1
+
+CMD ["airflow", "triggerer"]

--- a/control-plane/webserver/Dockerfile
+++ b/control-plane/webserver/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim
+
+ENV AIRFLOW_HOME=/opt/airflow \
+    AIRFLOW_VERSION=3.0.4 \
+    PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 50000 airflow \
+    && useradd --uid 50000 --gid airflow --home-dir ${AIRFLOW_HOME} --create-home airflow
+
+USER airflow
+WORKDIR ${AIRFLOW_HOME}
+
+RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
+
+COPY ../scripts/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl --fail http://localhost:8080/health || exit 1
+
+CMD ["airflow", "webserver"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for Airflow 3.0.4 webserver, scheduler, and triggerer running as non-root with healthchecks
- include shared entrypoint and build script
- wire up Makefile targets for building control plane images

## Testing
- `sh -n control-plane/scripts/entrypoint.sh`
- `sh -n control-plane/build.sh`
- `make build-webserver` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a9bd1abc832ca30b3d0017e03598