### PR TITLE
Add kind-based development environment with Helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: build-webserver build-scheduler build-triggerer build-control-plane
+.PHONY: build-webserver build-scheduler build-triggerer build-control-plane kind-up kind-down
+
+KIND_CLUSTER_NAME ?= airbridge
+HELM_RELEASE ?= airbridge-control-plane
 
 build-webserver:
 	docker build -t airbridge-webserver:3.0.4 -f control-plane/webserver/Dockerfile control-plane
@@ -10,3 +13,14 @@ build-triggerer:
 	docker build -t airbridge-triggerer:3.0.4 -f control-plane/triggerer/Dockerfile control-plane
 
 build-control-plane: build-webserver build-scheduler build-triggerer
+
+kind-up: build-control-plane
+	kind create cluster --name $(KIND_CLUSTER_NAME)
+	kind load docker-image airbridge-webserver:3.0.4 --name $(KIND_CLUSTER_NAME)
+	kind load docker-image airbridge-scheduler:3.0.4 --name $(KIND_CLUSTER_NAME)
+	kind load docker-image airbridge-triggerer:3.0.4 --name $(KIND_CLUSTER_NAME)
+	helm upgrade --install $(HELM_RELEASE) infra/helm/airbridge -f infra/helm/airbridge/values-dev.yaml
+
+kind-down:
+	-helm uninstall $(HELM_RELEASE)
+	kind delete cluster --name $(KIND_CLUSTER_NAME)

--- a/docs/dev-k8s.md
+++ b/docs/dev-k8s.md
@@ -1,0 +1,40 @@
+# Local Kubernetes Development
+
+This guide describes how to run the AirBridge control plane on a local Kubernetes
+cluster using [kind](https://kind.sigs.k8s.io/) or Minikube.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [kind](https://kind.sigs.k8s.io/) or [Minikube](https://minikube.sigs.k8s.io/docs/start/)
+- [Helm](https://helm.sh/)
+
+## Quickstart
+
+```bash
+make kind-up
+```
+
+The command above creates a kind cluster, builds the control plane images, loads
+them into the cluster and deploys the Helm chart.
+
+To stop the cluster:
+
+```bash
+make kind-down
+```
+
+## Accessing the UI
+
+Port-forward the webserver service to reach the AirBridge UI locally:
+
+```bash
+kubectl port-forward service/airbridge-control-plane-webserver 8080:8080
+```
+
+Then open <http://localhost:8080> in your browser.
+
+## Running the Sample DAG
+
+A sample DAG is located in `samples/example_dag.py`. Upload it to the webserver
+via the AirBridge UI and trigger it to verify the installation.

--- a/infra/helm/airbridge/Chart.yaml
+++ b/infra/helm/airbridge/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: airbridge-control-plane
+description: Helm chart for AirBridge control plane for local development
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/infra/helm/airbridge/templates/_helpers.tpl
+++ b/infra/helm/airbridge/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "airbridge.fullname" -}}
+{{- .Release.Name -}}
+{{- end -}}

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "airbridge.fullname" . }}-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-scheduler
+  template:
+    metadata:
+      labels:
+        app: {{ include "airbridge.fullname" . }}-scheduler
+    spec:
+      containers:
+      - name: scheduler
+        image: "{{ .Values.scheduler.image }}:{{ .Values.scheduler.tag }}"
+        imagePullPolicy: {{ .Values.scheduler.pullPolicy }}

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "airbridge.fullname" . }}-triggerer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-triggerer
+  template:
+    metadata:
+      labels:
+        app: {{ include "airbridge.fullname" . }}-triggerer
+    spec:
+      containers:
+      - name: triggerer
+        image: "{{ .Values.triggerer.image }}:{{ .Values.triggerer.tag }}"
+        imagePullPolicy: {{ .Values.triggerer.pullPolicy }}

--- a/infra/helm/airbridge/templates/webserver-deployment.yaml
+++ b/infra/helm/airbridge/templates/webserver-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "airbridge.fullname" . }}-webserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-webserver
+  template:
+    metadata:
+      labels:
+        app: {{ include "airbridge.fullname" . }}-webserver
+    spec:
+      containers:
+      - name: webserver
+        image: "{{ .Values.webserver.image }}:{{ .Values.webserver.tag }}"
+        imagePullPolicy: {{ .Values.webserver.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.webserver.service.port }}

--- a/infra/helm/airbridge/templates/webserver-service.yaml
+++ b/infra/helm/airbridge/templates/webserver-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "airbridge.fullname" . }}-webserver
+spec:
+  type: {{ .Values.webserver.service.type | default "ClusterIP" }}
+  selector:
+    app: {{ include "airbridge.fullname" . }}-webserver
+  ports:
+  - port: {{ .Values.webserver.service.port }}
+    targetPort: {{ .Values.webserver.service.port }}

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -1,0 +1,16 @@
+# Values tuned for local kind or minikube cluster
+webserver:
+  image: airbridge-webserver
+  tag: "3.0.4"
+  pullPolicy: IfNotPresent
+  service:
+    port: 8080
+    type: ClusterIP
+scheduler:
+  image: airbridge-scheduler
+  tag: "3.0.4"
+  pullPolicy: IfNotPresent
+triggerer:
+  image: airbridge-triggerer
+  tag: "3.0.4"
+  pullPolicy: IfNotPresent

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -1,0 +1,14 @@
+webserver:
+  image: airbridge-webserver
+  tag: "3.0.4"
+  pullPolicy: IfNotPresent
+  service:
+    port: 8080
+scheduler:
+  image: airbridge-scheduler
+  tag: "3.0.4"
+  pullPolicy: IfNotPresent
+triggerer:
+  image: airbridge-triggerer
+  tag: "3.0.4"
+  pullPolicy: IfNotPresent

--- a/samples/example_dag.py
+++ b/samples/example_dag.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+
+with DAG(
+    dag_id="example_dag",
+    start_date=datetime(2023, 1, 1),
+    schedule_interval="@once",
+    catchup=False,
+) as dag:
+    BashOperator(task_id="hello", bash_command="echo 'Hello from AirBridge'")


### PR DESCRIPTION
## Summary
- add Helm chart and dev values for deploying AirBridge control plane
- add `kind-up`/`kind-down` targets for local Kubernetes cluster
- document Kubernetes development workflow and sample DAG

## Testing
- `helm lint infra/helm/airbridge`
- `make kind-up` *(fails: docker: No such file or directory)*
- `make kind-down` *(fails: Kubernetes cluster unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ab6097f4832ca7f3424865249763