### PR TITLE
Fix Airflow PATH and add CI test for control plane images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Placeholder
-        run: echo "CI placeholder"
+      - name: Build control plane images
+        run: make build-control-plane
+      - name: Verify Airflow CLI
+        run: |
+          docker run --rm airbridge-webserver:3.0.4 airflow version
+          docker run --rm airbridge-scheduler:3.0.4 airflow version
+          docker run --rm airbridge-triggerer:3.0.4 airflow version

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # AirBridge
 Build a control-plane/data-plane Airflow on 3.0.4 using Edge Executor. Control plane hosts web/API, scheduler, triggerer, DB; data planes run lightweight edge workers with outbound-only HTTPS. DAGs and logs are centralized in S3.
+
+## Building and Testing
+
+The control-plane services (webserver, scheduler, and triggerer) are built as Docker images. Use the Makefile to build all three:
+
+```
+make build-control-plane
+```
+
+Each image runs an entrypoint that performs `airflow db migrate` before starting the service. The CI workflow builds these images and verifies that the Airflow CLI is available to prevent regressions.

--- a/control-plane/scheduler/Dockerfile
+++ b/control-plane/scheduler/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
 
 ENV AIRFLOW_HOME=/opt/airflow \
-    AIRFLOW_VERSION=3.0.4 \
-    PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
+    AIRFLOW_VERSION=3.0.4
+ENV PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
 
 RUN set -ex \
     && apt-get update \
@@ -16,7 +16,7 @@ WORKDIR ${AIRFLOW_HOME}
 
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
-COPY ../scripts/entrypoint.sh /entrypoint.sh
+COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD airflow jobs check --job-type SchedulerJob || exit 1

--- a/control-plane/triggerer/Dockerfile
+++ b/control-plane/triggerer/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
 
 ENV AIRFLOW_HOME=/opt/airflow \
-    AIRFLOW_VERSION=3.0.4 \
-    PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
+    AIRFLOW_VERSION=3.0.4
+ENV PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
 
 RUN set -ex \
     && apt-get update \
@@ -16,7 +16,7 @@ WORKDIR ${AIRFLOW_HOME}
 
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
-COPY ../scripts/entrypoint.sh /entrypoint.sh
+COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD airflow jobs check --job-type TriggererJob || exit 1

--- a/control-plane/webserver/Dockerfile
+++ b/control-plane/webserver/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.11-slim
 
 ENV AIRFLOW_HOME=/opt/airflow \
-    AIRFLOW_VERSION=3.0.4 \
-    PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
+    AIRFLOW_VERSION=3.0.4
+ENV PATH="${AIRFLOW_HOME}/.local/bin:${PATH}"
 
 RUN set -ex \
     && apt-get update \
@@ -16,7 +16,7 @@ WORKDIR ${AIRFLOW_HOME}
 
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
-COPY ../scripts/entrypoint.sh /entrypoint.sh
+COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- fix Dockerfiles so Airflow CLI is on PATH and entrypoint is copied
- add CI job to build control plane images and verify `airflow` command
- document build instructions for the control-plane images

## Testing
- `make build-control-plane` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b0112190832c80f286ef2c4b1e26