### PR TITLE
Enable Edge Executor and secure Edge API

### DIFF
--- a/control-plane/airflow.cfg
+++ b/control-plane/airflow.cfg
@@ -1,0 +1,5 @@
+[core]
+executor = EdgeExecutor
+
+# Edge API enabled via environment variables; token provided through
+# the EDGE_API_TOKEN environment variable.

--- a/control-plane/scheduler/Dockerfile
+++ b/control-plane/scheduler/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR ${AIRFLOW_HOME}
 
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
+COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
+
 COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/control-plane/triggerer/Dockerfile
+++ b/control-plane/triggerer/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR ${AIRFLOW_HOME}
 
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
+COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
+
 COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/control-plane/webserver/Dockerfile
+++ b/control-plane/webserver/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR ${AIRFLOW_HOME}
 
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
+COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
+
 COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/docs/control-plane-config.md
+++ b/docs/control-plane-config.md
@@ -1,0 +1,22 @@
+# Control Plane Configuration
+
+The control plane ships with an Airflow configuration tailored for edge execution.
+Key settings include:
+
+- `[core] executor = EdgeExecutor`
+- Edge API enabled so edge workers can communicate with the control plane.
+- Token based authentication for the Edge API; tokens are supplied via environment variables.
+
+## Enabling the Edge API
+
+1. Create a Kubernetes secret containing the token:
+   ```bash
+   kubectl create secret generic edge-api-token --from-literal=token=<token>
+   ```
+2. Set `.Values.edgeApi.enabled` to `true` and provide the secret name via
+   `.Values.edgeApi.tokenSecretName` in the Helm chart values.
+3. The webserver deployment reads the token from the secret and exposes it to
+   Airflow via the `EDGE_API_TOKEN` environment variable.
+
+With these settings the scheduler runs using the `EdgeExecutor` and the webserver
+exposes the authenticated Edge API.

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -16,3 +16,6 @@ spec:
       - name: scheduler
         image: "{{ .Values.scheduler.image }}:{{ .Values.scheduler.tag }}"
         imagePullPolicy: {{ .Values.scheduler.pullPolicy }}
+        env:
+        - name: AIRFLOW__CORE__EXECUTOR
+          value: EdgeExecutor

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -16,3 +16,6 @@ spec:
       - name: triggerer
         image: "{{ .Values.triggerer.image }}:{{ .Values.triggerer.tag }}"
         imagePullPolicy: {{ .Values.triggerer.pullPolicy }}
+        env:
+        - name: AIRFLOW__CORE__EXECUTOR
+          value: EdgeExecutor

--- a/infra/helm/airbridge/templates/webserver-deployment.yaml
+++ b/infra/helm/airbridge/templates/webserver-deployment.yaml
@@ -16,5 +16,15 @@ spec:
       - name: webserver
         image: "{{ .Values.webserver.image }}:{{ .Values.webserver.tag }}"
         imagePullPolicy: {{ .Values.webserver.pullPolicy }}
+        env:
+        - name: AIRFLOW__CORE__EXECUTOR
+          value: EdgeExecutor
+        - name: AIRFLOW__API__EDGE__ENABLED
+          value: {{ .Values.edgeApi.enabled | quote }}
+        - name: EDGE_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.edgeApi.tokenSecretName }}
+              key: token
         ports:
         - containerPort: {{ .Values.webserver.service.port }}

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -14,3 +14,7 @@ triggerer:
   image: airbridge-triggerer
   tag: "3.0.4"
   pullPolicy: IfNotPresent
+
+edgeApi:
+  enabled: true
+  tokenSecretName: edge-api-token

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -12,3 +12,7 @@ triggerer:
   image: airbridge-triggerer
   tag: "3.0.4"
   pullPolicy: IfNotPresent
+
+edgeApi:
+  enabled: true
+  tokenSecretName: edge-api-token


### PR DESCRIPTION
## Summary
- run Airflow with `EdgeExecutor` via shared `airflow.cfg`
- expose the Edge API using token-based auth and Helm values
- document control plane configuration and secret management

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc33b954832cbb0e231253d3f0aa