### PR TITLE
Provide placeholder EdgeExecutor module

### DIFF
--- a/control-plane/airflow.cfg
+++ b/control-plane/airflow.cfg
@@ -1,5 +1,7 @@
 [core]
-executor = EdgeExecutor
+# Use the custom EdgeExecutor implementation. The fully qualified module path
+# ensures Airflow can import the executor when the configuration is loaded.
+executor = edge_executor.EdgeExecutor
 
 # Edge API enabled via environment variables; token provided through
 # the EDGE_API_TOKEN environment variable.

--- a/control-plane/edge_executor.py
+++ b/control-plane/edge_executor.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Minimal EdgeExecutor implementation.
+
+This executor currently delegates all work to Airflow's ``LocalExecutor``.
+It exists to allow the control plane to reference ``edge_executor.EdgeExecutor``
+without failing to import the executor class. Future iterations may extend
+this class with edge specific behavior.
+"""
+
+from airflow.executors.local_executor import LocalExecutor
+
+
+class EdgeExecutor(LocalExecutor):
+    """Placeholder executor for edge execution.
+
+    This executor subclasses :class:`~airflow.executors.local_executor.LocalExecutor`
+    and does not add any custom behavior. It enables AirBridge to configure a
+    custom executor path while the real implementation is developed.
+    """
+
+    pass

--- a/control-plane/scheduler/Dockerfile
+++ b/control-plane/scheduler/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR ${AIRFLOW_HOME}
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
 COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
+COPY edge_executor.py ${AIRFLOW_HOME}/edge_executor.py
 
 COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/control-plane/triggerer/Dockerfile
+++ b/control-plane/triggerer/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR ${AIRFLOW_HOME}
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
 COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
+COPY edge_executor.py ${AIRFLOW_HOME}/edge_executor.py
 
 COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/control-plane/webserver/Dockerfile
+++ b/control-plane/webserver/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR ${AIRFLOW_HOME}
 RUN pip install --no-cache-dir "apache-airflow==${AIRFLOW_VERSION}"
 
 COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
+COPY edge_executor.py ${AIRFLOW_HOME}/edge_executor.py
 
 COPY scripts/entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docs/control-plane-config.md
+++ b/docs/control-plane-config.md
@@ -3,7 +3,7 @@
 The control plane ships with an Airflow configuration tailored for edge execution.
 Key settings include:
 
-- `[core] executor = EdgeExecutor`
+- `[core] executor = edge_executor.EdgeExecutor`
 - Edge API enabled so edge workers can communicate with the control plane.
 - Token based authentication for the Edge API; tokens are supplied via environment variables.
 

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -18,4 +18,4 @@ spec:
         imagePullPolicy: {{ .Values.scheduler.pullPolicy }}
         env:
         - name: AIRFLOW__CORE__EXECUTOR
-          value: EdgeExecutor
+          value: edge_executor.EdgeExecutor

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -18,4 +18,4 @@ spec:
         imagePullPolicy: {{ .Values.triggerer.pullPolicy }}
         env:
         - name: AIRFLOW__CORE__EXECUTOR
-          value: EdgeExecutor
+          value: edge_executor.EdgeExecutor

--- a/infra/helm/airbridge/templates/webserver-deployment.yaml
+++ b/infra/helm/airbridge/templates/webserver-deployment.yaml
@@ -18,7 +18,7 @@ spec:
         imagePullPolicy: {{ .Values.webserver.pullPolicy }}
         env:
         - name: AIRFLOW__CORE__EXECUTOR
-          value: EdgeExecutor
+          value: edge_executor.EdgeExecutor
         - name: AIRFLOW__API__EDGE__ENABLED
           value: {{ .Values.edgeApi.enabled | quote }}
         - name: EDGE_API_TOKEN


### PR DESCRIPTION
## Summary
- add minimal `EdgeExecutor` subclassing `LocalExecutor`
- configure Airflow and Helm templates to load executor from `edge_executor.EdgeExecutor`
- copy executor module into control plane Docker images and document module path

## Testing
- `python -m py_compile control-plane/edge_executor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0bff581c0832c82f5d7fa8379362d