### PR TITLE
fix: expose edge executor module for Airflow

### DIFF
--- a/edge_executor.py
+++ b/edge_executor.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Minimal EdgeExecutor implementation for AirBridge.
+
+This module is placed at the repository root so that ``edge_executor`` can
+be imported without additional ``PYTHONPATH`` configuration. The
+implementation currently delegates all work to Airflow's
+:class:`~airflow.executors.local_executor.LocalExecutor` and acts as a
+placeholder for future edge-specific behavior.
+"""
+
+from airflow.executors.local_executor import LocalExecutor
+
+
+class EdgeExecutor(LocalExecutor):
+    """Placeholder executor for edge execution.
+
+    This executor subclasses
+    :class:`~airflow.executors.local_executor.LocalExecutor` and does not
+    add any custom behavior. It enables AirBridge to configure a custom
+    executor path while the real implementation is developed.
+    """
+
+    pass


### PR DESCRIPTION
## Summary
- expose `edge_executor` module at repo root so Airflow can import custom executor without extra PYTHONPATH

## Testing
- `python -m py_compile edge_executor.py control-plane/edge_executor.py`
- `PYTHONPATH=$PWD AIRFLOW_HOME=$PWD AIRFLOW__CORE__EXECUTOR=edge_executor.EdgeExecutor airflow info`

------
https://chatgpt.com/codex/tasks/task_e_68a1484331f4832c8f2b7bcfd7e8ae71