### PR TITLE
Add packaging and tests for EdgeExecutor import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,9 @@ __pycache__/
 *.py[cod]
 .env
 
+# Packaging
+*.egg-info/
+build/
+
 # Others
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[metadata]
+name = airbridge-edge-executor
+version = 0.1.0
+description = EdgeExecutor placeholder for AirBridge
+
+[options]
+py_modules = edge_executor

--- a/tests/test_edge_executor_import.py
+++ b/tests/test_edge_executor_import.py
@@ -1,0 +1,41 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_edge_executor_importable(tmp_path):
+    """EdgeExecutor should be importable via Airflow's ExecutorLoader.
+
+    The test installs the project package and then imports the executor from a
+    separate working directory to ensure the module is available on the
+    ``PYTHONPATH``. This mimics Airflow's runtime environment where the current
+    working directory is unrelated to the project source tree.
+    """
+
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", PROJECT_ROOT.as_posix()],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from airflow.executors.executor_loader import ExecutorLoader, ExecutorName;"
+            "ExecutorLoader.import_executor_cls(ExecutorName('edge_executor.EdgeExecutor'))",
+        ],
+        check=True,
+        cwd=tmp_path,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )

--- a/tests/test_edge_executor_pipeline.py
+++ b/tests/test_edge_executor_pipeline.py
@@ -1,0 +1,49 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dag_runs_with_edge_executor(tmp_path):
+    """A simple DAG should execute using EdgeExecutor."""
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", PROJECT_ROOT.as_posix()],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    dag_script = (
+        "from datetime import datetime\n"
+        "from airflow import DAG\n"
+        "from airflow.operators.empty import EmptyOperator\n"
+        "with DAG('edge_test', start_date=datetime(2024,1,1), schedule=None) as dag:\n"
+        "    EmptyOperator(task_id='t1')\n"
+        "dag.test(run_after=None, use_executor=True)\n"
+    )
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env["AIRFLOW__CORE__EXECUTOR"] = "edge_executor.EdgeExecutor"
+    env["AIRFLOW_HOME"] = str(tmp_path)
+    env["AIRFLOW__DATABASE__SQL_ALCHEMY_CONN"] = f"sqlite:///{tmp_path/'airflow.db'}"
+
+    subprocess.run(
+        [sys.executable, "-m", "airflow", "db", "migrate"],
+        check=True,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", dag_script],
+        check=True,
+        cwd=tmp_path,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )


### PR DESCRIPTION
## Summary
- package EdgeExecutor so it can be installed and referenced in Airflow
- add unit tests for executor import and simple DAG pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a14b420b08832ca740edaa9b13725e