### PR TITLE
Add EdgeExecutor example DAG and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,38 @@ make build-control-plane
 ```
 
 Each image runs an entrypoint that performs `airflow db migrate` before starting the service. The CI workflow builds these images and verifies that the Airflow CLI is available to prevent regressions.
+
+## Edge sample DAG
+
+An example DAG demonstrating the **EdgeExecutor** is provided in
+`opt/airflow/dags/edge_sample_dag.py`.
+
+### Deploy
+1. Copy the DAG file to your Airflow instance, e.g.:
+   ```bash
+   cp opt/airflow/dags/edge_sample_dag.py /opt/airflow/dags/
+   ```
+2. Configure Airflow to use the executor:
+   ```bash
+   export AIRFLOW__CORE__EXECUTOR=edge_executor.EdgeExecutor
+   ```
+3. Start the scheduler and webserver so the DAG appears in the UI.
+
+### Run
+- **Web UI:** enable the DAG and click *Trigger DAG*.
+- **CLI:**
+  ```bash
+  airflow dags trigger edge_sample_dag
+  ```
+- **Smoke tests:**
+  ```bash
+  airflow tasks test edge_sample_dag start 2024-01-01
+  airflow tasks test edge_sample_dag finish 2024-01-01
+  ```
+
+### Troubleshooting
+- DAG not showing up? Ensure it resides in Airflow's `dags_folder`
+  (default `/opt/airflow/dags`).
+- Import errors? Check the scheduler logs for stack traces.
+- Missing dependencies? Verify the worker image contains this project and
+  Airflow can import the operators used in the DAG.

--- a/opt/airflow/dags/edge_sample_dag.py
+++ b/opt/airflow/dags/edge_sample_dag.py
@@ -1,0 +1,40 @@
+"""Example DAG demonstrating EdgeExecutor usage.
+
+This DAG is designed for environments that run tasks on the EdgeExecutor.
+Each task explicitly targets the ``edge`` queue so it will be picked up by
+edge workers. The workflow contains two simple tasks with a clear
+upstream/downstream relationship.
+"""
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
+
+
+def _finish() -> None:
+    """Log completion of the DAG."""
+    print("Edge sample DAG finished")
+
+
+with DAG(
+    dag_id="edge_sample_dag",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["edge", "example"],
+) as dag:
+    start = BashOperator(
+        task_id="start",
+        bash_command="echo 'Start edge sample DAG'",
+        queue="edge",
+    )
+
+    finish = PythonOperator(
+        task_id="finish",
+        python_callable=_finish,
+        queue="edge",
+    )
+
+    start >> finish

--- a/tests/test_edge_sample_dag.py
+++ b/tests/test_edge_sample_dag.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from airflow.models.dagbag import DagBag
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DAG_PATH = PROJECT_ROOT / "opt" / "airflow" / "dags"
+
+
+def test_edge_sample_dag_loaded():
+    dagbag = DagBag(dag_folder=str(DAG_PATH), include_examples=False)
+    assert "edge_sample_dag" in dagbag.dags
+    dag = dagbag.dags["edge_sample_dag"]
+    assert set(dag.task_ids) == {"start", "finish"}


### PR DESCRIPTION
## Summary
- add sample DAG using EdgeExecutor
- document deployment and execution instructions
- verify DAG import through DagBag test

## Testing
- `pytest tests/test_edge_sample_dag.py -q`
- `pytest tests/test_edge_executor_import.py -q` *(fails: ModuleNotFoundError: No module named 'edge_executor')*
- `pytest tests/test_edge_executor_pipeline.py -q` *(fails: Command ... returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a15c009c40832c814168c4dd7e195b