### PR TITLE
feat: add control plane helm chart

### DIFF
--- a/docs/deploy/helm-control-plane.md
+++ b/docs/deploy/helm-control-plane.md
@@ -1,0 +1,23 @@
+# AirBridge Control Plane Helm Chart
+
+This chart deploys the AirBridge control plane (Airflow webserver, scheduler, and triggerer)
+into a Kubernetes cluster. The database is expected to be managed externally.
+
+## Usage
+
+Choose the values file for your environment and install with Helm:
+
+```bash
+helm install airbridge-control-plane infra/helm/airbridge -f infra/helm/airbridge/values-dev.yaml
+```
+
+Replace `values-dev.yaml` with `values-stage.yaml` or `values-prod.yaml` for other
+environments.
+
+## Configuration
+
+* **Airflow configuration** – provided via `airflow.config` and mounted as `airflow.cfg`.
+* **Optional components** – enable Flower by setting `flower.enabled=true`.
+* **Scaling** – HPAs and PodDisruptionBudgets are controlled via values for each component.
+
+See `infra/helm/airbridge/values.yaml` for the full list of configurable values.

--- a/infra/helm/airbridge/Chart.yaml
+++ b/infra/helm/airbridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: airbridge-control-plane
-description: Helm chart for AirBridge control plane for local development
+description: Helm chart for AirBridge control plane
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/infra/helm/airbridge/templates/airflow-configmap.yaml
+++ b/infra/helm/airbridge/templates/airflow-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "airbridge.fullname" . }}-config
+data:
+  airflow.cfg: |
+{{ .Values.airflow.config | nindent 4 }}

--- a/infra/helm/airbridge/templates/edge-api-secret.yaml
+++ b/infra/helm/airbridge/templates/edge-api-secret.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.edgeApi.enabled .Values.edgeApi.createSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.edgeApi.tokenSecretName }}
+type: Opaque
+data:
+  token: {{ .Values.edgeApi.token | b64enc }}
+{{- end }}

--- a/infra/helm/airbridge/templates/flower-deployment.yaml
+++ b/infra/helm/airbridge/templates/flower-deployment.yaml
@@ -1,21 +1,23 @@
+{{- if .Values.flower.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "airbridge.fullname" . }}-webserver
+  name: {{ include "airbridge.fullname" . }}-flower
 spec:
-  replicas: {{ .Values.webserver.replicas }}
+  replicas: {{ .Values.flower.replicas }}
   selector:
     matchLabels:
-      app: {{ include "airbridge.fullname" . }}-webserver
+      app: {{ include "airbridge.fullname" . }}-flower
   template:
     metadata:
       labels:
-        app: {{ include "airbridge.fullname" . }}-webserver
+        app: {{ include "airbridge.fullname" . }}-flower
     spec:
       containers:
-      - name: webserver
-        image: "{{ .Values.webserver.image }}:{{ .Values.webserver.tag }}"
-        imagePullPolicy: {{ .Values.webserver.pullPolicy }}
+      - name: flower
+        image: "{{ .Values.flower.image }}:{{ .Values.flower.tag }}"
+        imagePullPolicy: {{ .Values.flower.pullPolicy }}
+        args: ["flower"]
         env:
         - name: AIRFLOW__CORE__EXECUTOR
           value: {{ .Values.airflow.executor | quote }}
@@ -27,17 +29,17 @@ spec:
               name: {{ .Values.edgeApi.tokenSecretName }}
               key: token
         ports:
-        - containerPort: {{ .Values.webserver.service.port }}
+        - containerPort: {{ .Values.flower.service.port }}
         livenessProbe:
           httpGet:
             path: /
-            port: {{ .Values.webserver.service.port }}
+            port: {{ .Values.flower.service.port }}
           initialDelaySeconds: 10
           periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /
-            port: {{ .Values.webserver.service.port }}
+            port: {{ .Values.flower.service.port }}
           initialDelaySeconds: 5
           periodSeconds: 10
         volumeMounts:
@@ -48,3 +50,4 @@ spec:
       - name: airflow-config
         configMap:
           name: {{ include "airbridge.fullname" . }}-config
+{{- end }}

--- a/infra/helm/airbridge/templates/flower-hpa.yaml
+++ b/infra/helm/airbridge/templates/flower-hpa.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.flower.enabled .Values.flower.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "airbridge.fullname" . }}-flower
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "airbridge.fullname" . }}-flower
+  minReplicas: {{ .Values.flower.hpa.minReplicas }}
+  maxReplicas: {{ .Values.flower.hpa.maxReplicas }}
+  metrics:
+{{- toYaml .Values.flower.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/infra/helm/airbridge/templates/flower-pdb.yaml
+++ b/infra/helm/airbridge/templates/flower-pdb.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.flower.enabled .Values.flower.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airbridge.fullname" . }}-flower
+spec:
+  minAvailable: {{ .Values.flower.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-flower
+{{- end }}

--- a/infra/helm/airbridge/templates/flower-service.yaml
+++ b/infra/helm/airbridge/templates/flower-service.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.flower.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "airbridge.fullname" . }}-flower
+spec:
+  type: {{ .Values.flower.service.type | default "ClusterIP" }}
+  selector:
+    app: {{ include "airbridge.fullname" . }}-flower
+  ports:
+  - port: {{ .Values.flower.service.port }}
+    targetPort: {{ .Values.flower.service.port }}
+{{- end }}

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "airbridge.fullname" . }}-scheduler
 spec:
-  replicas: 1
+  replicas: {{ .Values.scheduler.replicas }}
   selector:
     matchLabels:
       app: {{ include "airbridge.fullname" . }}-scheduler
@@ -18,4 +18,29 @@ spec:
         imagePullPolicy: {{ .Values.scheduler.pullPolicy }}
         env:
         - name: AIRFLOW__CORE__EXECUTOR
-          value: airflow.providers.edge3.executors.EdgeExecutor
+          value: {{ .Values.airflow.executor | quote }}
+        - name: AIRFLOW__API__EDGE__ENABLED
+          value: {{ .Values.edgeApi.enabled | quote }}
+        - name: EDGE_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.edgeApi.tokenSecretName }}
+              key: token
+        livenessProbe:
+          exec:
+            command: ["bash", "-c", "airflow jobs check scheduler"]
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          exec:
+            command: ["bash", "-c", "airflow jobs check scheduler"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: airflow-config
+          mountPath: /opt/airflow/airflow.cfg
+          subPath: airflow.cfg
+      volumes:
+      - name: airflow-config
+        configMap:
+          name: {{ include "airbridge.fullname" . }}-config

--- a/infra/helm/airbridge/templates/scheduler-hpa.yaml
+++ b/infra/helm/airbridge/templates/scheduler-hpa.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.scheduler.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "airbridge.fullname" . }}-scheduler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "airbridge.fullname" . }}-scheduler
+  minReplicas: {{ .Values.scheduler.hpa.minReplicas }}
+  maxReplicas: {{ .Values.scheduler.hpa.maxReplicas }}
+  metrics:
+{{- toYaml .Values.scheduler.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/infra/helm/airbridge/templates/scheduler-pdb.yaml
+++ b/infra/helm/airbridge/templates/scheduler-pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.scheduler.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airbridge.fullname" . }}-scheduler
+spec:
+  minAvailable: {{ .Values.scheduler.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-scheduler
+{{- end }}

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "airbridge.fullname" . }}-triggerer
 spec:
-  replicas: 1
+  replicas: {{ .Values.triggerer.replicas }}
   selector:
     matchLabels:
       app: {{ include "airbridge.fullname" . }}-triggerer
@@ -18,4 +18,29 @@ spec:
         imagePullPolicy: {{ .Values.triggerer.pullPolicy }}
         env:
         - name: AIRFLOW__CORE__EXECUTOR
-          value: airflow.providers.edge3.executors.EdgeExecutor
+          value: {{ .Values.airflow.executor | quote }}
+        - name: AIRFLOW__API__EDGE__ENABLED
+          value: {{ .Values.edgeApi.enabled | quote }}
+        - name: EDGE_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.edgeApi.tokenSecretName }}
+              key: token
+        livenessProbe:
+          exec:
+            command: ["bash", "-c", "airflow jobs check triggerer"]
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          exec:
+            command: ["bash", "-c", "airflow jobs check triggerer"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: airflow-config
+          mountPath: /opt/airflow/airflow.cfg
+          subPath: airflow.cfg
+      volumes:
+      - name: airflow-config
+        configMap:
+          name: {{ include "airbridge.fullname" . }}-config

--- a/infra/helm/airbridge/templates/triggerer-hpa.yaml
+++ b/infra/helm/airbridge/templates/triggerer-hpa.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.triggerer.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "airbridge.fullname" . }}-triggerer
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "airbridge.fullname" . }}-triggerer
+  minReplicas: {{ .Values.triggerer.hpa.minReplicas }}
+  maxReplicas: {{ .Values.triggerer.hpa.maxReplicas }}
+  metrics:
+{{- toYaml .Values.triggerer.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/infra/helm/airbridge/templates/triggerer-pdb.yaml
+++ b/infra/helm/airbridge/templates/triggerer-pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.triggerer.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airbridge.fullname" . }}-triggerer
+spec:
+  minAvailable: {{ .Values.triggerer.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-triggerer
+{{- end }}

--- a/infra/helm/airbridge/templates/webserver-hpa.yaml
+++ b/infra/helm/airbridge/templates/webserver-hpa.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.webserver.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "airbridge.fullname" . }}-webserver
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "airbridge.fullname" . }}-webserver
+  minReplicas: {{ .Values.webserver.hpa.minReplicas }}
+  maxReplicas: {{ .Values.webserver.hpa.maxReplicas }}
+  metrics:
+{{- toYaml .Values.webserver.hpa.metrics | nindent 4 }}
+{{- end }}

--- a/infra/helm/airbridge/templates/webserver-pdb.yaml
+++ b/infra/helm/airbridge/templates/webserver-pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.webserver.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "airbridge.fullname" . }}-webserver
+spec:
+  minAvailable: {{ .Values.webserver.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-webserver
+{{- end }}

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -3,6 +3,7 @@ webserver:
   image: airbridge-webserver
   tag: "3.0.4"
   pullPolicy: IfNotPresent
+  replicas: 1
   service:
     port: 8080
     type: ClusterIP
@@ -10,11 +11,21 @@ scheduler:
   image: airbridge-scheduler
   tag: "3.0.4"
   pullPolicy: IfNotPresent
+  replicas: 1
 triggerer:
   image: airbridge-triggerer
   tag: "3.0.4"
   pullPolicy: IfNotPresent
-
+  replicas: 1
+flower:
+  enabled: true
+  image: apache/airflow
+  tag: "2.7.1"
+  pullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    port: 5555
+    type: ClusterIP
 edgeApi:
   enabled: true
   tokenSecretName: edge-api-token
@@ -24,14 +35,13 @@ dags:
   persistence:
     enabled: true
     size: 5Gi
-    # Use an RWX class if multiple pods may run on different nodes.
-    # Common examples:
-    #  - EKS:  efs-sc
-    #  - AKS:  azurefile-csi
-    #  - GKE:  filestore-csi
-    storageClassName: standard 
-    accessMode: ReadWriteMany   # If your class only supports RWO, change to ReadWriteOnce
-
-  # If you prefer pulling DAGs from git, enable this instead of (or in addition to) manual uploads.
+    storageClassName: standard
+    accessMode: ReadWriteMany
   gitSync:
-    enabled: false     
+    enabled: false
+
+airflow:
+  executor: airflow.providers.edge3.executors.EdgeExecutor
+  config: |
+    [core]
+    load_examples = False

--- a/infra/helm/airbridge/values-prod.yaml
+++ b/infra/helm/airbridge/values-prod.yaml
@@ -1,0 +1,16 @@
+webserver:
+  replicas: 3
+  service:
+    type: LoadBalancer
+  hpa:
+    enabled: true
+scheduler:
+  replicas: 3
+  hpa:
+    enabled: true
+triggerer:
+  replicas: 3
+  hpa:
+    enabled: true
+flower:
+  enabled: false

--- a/infra/helm/airbridge/values-stage.yaml
+++ b/infra/helm/airbridge/values-stage.yaml
@@ -1,0 +1,10 @@
+webserver:
+  replicas: 2
+  service:
+    type: LoadBalancer
+scheduler:
+  replicas: 2
+triggerer:
+  replicas: 2
+flower:
+  enabled: false

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -2,21 +2,99 @@ webserver:
   image: airbridge-webserver
   tag: "3.0.4"
   pullPolicy: IfNotPresent
+  replicas: 1
   service:
     port: 8080
+    type: ClusterIP
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
 scheduler:
   image: airbridge-scheduler
   tag: "3.0.4"
   pullPolicy: IfNotPresent
+  replicas: 1
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
 triggerer:
   image: airbridge-triggerer
   tag: "3.0.4"
   pullPolicy: IfNotPresent
-
+  replicas: 1
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
+flower:
+  enabled: false
+  image: apache/airflow
+  tag: "2.7.1"
+  pullPolicy: IfNotPresent
+  replicas: 1
+  service:
+    port: 5555
+    type: ClusterIP
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 80
+  pdb:
+    enabled: false
+    minAvailable: 1
 edgeApi:
   enabled: true
   tokenSecretName: edge-api-token
+  createSecret: false
+  token: ""
 
+airflow:
+  executor: airflow.providers.edge3.executors.EdgeExecutor
+  config: |
+    [core]
+    load_examples = False
+
+# DAG volume and git sync configurations are unchanged
+# from previous chart versions.
 dags:
   path: /opt/airflow/dags
   persistence:
@@ -27,9 +105,9 @@ dags:
     #  - EKS:  efs-sc
     #  - AKS:  azurefile-csi
     #  - GKE:  filestore-csi
-    storageClassName: standard 
+    storageClassName: standard
     accessMode: ReadWriteMany   # If your class only supports RWO, change to ReadWriteOnce
 
   # If you prefer pulling DAGs from git, enable this instead of (or in addition to) manual uploads.
   gitSync:
-    enabled: false   
+    enabled: false


### PR DESCRIPTION
## Summary
- package AirBridge control plane components into a Helm chart
- expose environment-specific values and optional Flower deployment
- document Helm-based deployment

## Testing
- `helm lint infra/helm/airbridge`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'edge_executor')*

------
https://chatgpt.com/codex/tasks/task_e_68a188e3e4a4832caa467011d2043e62