### PR TITLE
fix: provide default edge API secrets

### DIFF
--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -29,6 +29,8 @@ flower:
 edgeApi:
   enabled: true
   tokenSecretName: edge-api-token
+  createSecret: true
+  token: dev-token
 
 dags:
   path: /opt/airflow/dags
@@ -45,3 +47,5 @@ airflow:
   config: |
     [core]
     load_examples = False
+    [api_auth]
+    jwt_secret = dev-jwt-secret

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -92,6 +92,8 @@ airflow:
   config: |
     [core]
     load_examples = False
+    [api_auth]
+    jwt_secret = change_me
 
 # DAG volume and git sync configurations are unchanged
 # from previous chart versions.


### PR DESCRIPTION
## Summary
- ensure dev Helm values create an edge API token secret with a sample token
- include an API auth JWT secret in Helm values to prevent startup errors

## Testing
- `pytest` *(fails: ModuleNotFoundError for edge_executor, DAG missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a18f126e98832c9c4d8d29436dadd7