### PR TITLE
Add configurable Ingress with TLS for control plane

### DIFF
--- a/docs/control-plane-config.md
+++ b/docs/control-plane-config.md
@@ -20,3 +20,20 @@ Key settings include:
 
 With these settings the scheduler runs using the `EdgeExecutor` and the webserver
 exposes the authenticated Edge API.
+
+## Ingress and TLS
+
+The control-plane UI and API can be exposed through a Kubernetes Ingress. Enable
+it by setting `.Values.ingress.enabled` and providing the desired `controller`
+(`nginx` or `gke`) and `host` in your values file. TLS certificates may be
+referenced via a secret, ACM ARN, or cert-manager issuer using the
+`ingress.tls` block.
+
+Optional security features include IP allow lists, basic rate limiting and WAF
+integration. For NGINX, supply ranges in `ingress.ipAllowList` and set
+`ingress.waf.enabled` to activate ModSecurity. On GKE, a Cloud Armor policy name
+can be provided in `ingress.waf.securityPolicy`.
+
+Expose a health check endpoint with `ingress.healthCheckPath` and ensure your
+monitoring system tracks 4xx and 5xx response rates for early detection of
+problems.

--- a/infra/helm/airbridge/templates/webserver-ingress.yaml
+++ b/infra/helm/airbridge/templates/webserver-ingress.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "airbridge.fullname" . }}-webserver
+  annotations:
+    {{- if eq .Values.ingress.controller "nginx" }}
+    kubernetes.io/ingress.class: nginx
+    {{- if .Values.ingress.ipAllowList }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ join "," .Values.ingress.ipAllowList | quote }}
+    {{- end }}
+    {{- if .Values.ingress.rateLimit.rps }}
+    nginx.ingress.kubernetes.io/limit-rps: "{{ .Values.ingress.rateLimit.rps }}"
+    {{- end }}
+    {{- if .Values.ingress.rateLimit.burst }}
+    nginx.ingress.kubernetes.io/limit-burst: "{{ .Values.ingress.rateLimit.burst }}"
+    {{- end }}
+    {{- if .Values.ingress.waf.enabled }}
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    {{- end }}
+    {{- if .Values.ingress.healthCheckPath }}
+    nginx.ingress.kubernetes.io/health-check-path: {{ .Values.ingress.healthCheckPath | quote }}
+    {{- end }}
+    {{- else if eq .Values.ingress.controller "gke" }}
+    kubernetes.io/ingress.class: gce
+    {{- if .Values.ingress.waf.securityPolicy }}
+    networking.gke.io/security-policy: {{ .Values.ingress.waf.securityPolicy | quote }}
+    {{- end }}
+    {{- if .Values.ingress.healthCheckPath }}
+    ingress.gcp.kubernetes.io/healthcheck-path: {{ .Values.ingress.healthCheckPath | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.ingress.tls.acmCertificateArn }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.tls.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if .Values.ingress.tls.issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.issuer | quote }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      {{- if .Values.ingress.tls.secretName }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+      {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "airbridge.fullname" . }}-webserver
+                port:
+                  number: {{ .Values.webserver.service.port }}
+{{- end }}

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -32,6 +32,13 @@ edgeApi:
   createSecret: true
   token: dev-token
 
+ingress:
+  enabled: true
+  controller: nginx
+  host: airbridge.dev.local
+  tls:
+    enabled: false
+
 dags:
   path: /opt/airflow/dags
   persistence:

--- a/infra/helm/airbridge/values-prod.yaml
+++ b/infra/helm/airbridge/values-prod.yaml
@@ -1,7 +1,7 @@
 webserver:
   replicas: 3
   service:
-    type: LoadBalancer
+    type: ClusterIP
   hpa:
     enabled: true
 scheduler:
@@ -14,3 +14,11 @@ triggerer:
     enabled: true
 flower:
   enabled: false
+
+ingress:
+  enabled: true
+  controller: gke
+  host: airbridge.example.com
+  tls:
+    enabled: true
+    secretName: prod-cert

--- a/infra/helm/airbridge/values-stage.yaml
+++ b/infra/helm/airbridge/values-stage.yaml
@@ -1,10 +1,18 @@
 webserver:
   replicas: 2
   service:
-    type: LoadBalancer
+    type: ClusterIP
 scheduler:
   replicas: 2
 triggerer:
   replicas: 2
 flower:
   enabled: false
+
+ingress:
+  enabled: true
+  controller: gke
+  host: airbridge.stage.example.com
+  tls:
+    enabled: true
+    secretName: stage-cert

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -87,6 +87,26 @@ edgeApi:
   createSecret: false
   token: ""
 
+ingress:
+  enabled: false
+  controller: nginx # or gke
+  host: ""
+  className: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+    issuer: ""
+    acmCertificateArn: ""
+  ipAllowList: []
+  rateLimit:
+    rps: null
+    burst: null
+  waf:
+    enabled: false
+    securityPolicy: ""
+  healthCheckPath: /healthz
+
 airflow:
   executor: airflow.providers.edge3.executors.EdgeExecutor
   config: |


### PR DESCRIPTION
## Summary
- add NGINX/GKE ingress template for the control-plane webserver
- expose TLS, rate limiting, WAF and IP allow list options via values
- document ingress usage and health check monitoring guidance

## Testing
- `helm lint infra/helm/airbridge`
- `pytest` *(fails: ModuleNotFoundError: No module named 'airflow')*

------
https://chatgpt.com/codex/tasks/task_e_68a191f3f708832c88f9ce9143bda054