### PR TITLE
Add baseline Kubernetes bootstrap manifests

### DIFF
--- a/docs/deploy/bootstrap.md
+++ b/docs/deploy/bootstrap.md
@@ -1,0 +1,42 @@
+# Cluster Bootstrap
+
+Baseline Kubernetes resources required for all AirBridge environments.
+
+## Usage
+
+Apply the manifests:
+
+```bash
+kubectl apply -k infra/bootstrap
+```
+
+## Namespaces
+
+The kustomization creates the following namespaces with the Kubernetes
+[Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+`baseline` profile enforced:
+
+- `airbridge-system`
+- `airbridge-control`
+- `airbridge-edge`
+
+## Service Accounts and RBAC
+
+Service accounts are provided for the control plane and edge workers.  They
+are bound to cluster roles granting the permissions needed by each
+component.
+
+## Image Pull Secrets
+
+Docker registry credentials are defined in `infra/bootstrap/registry-creds.yaml`.
+Replace the placeholder data or create the secrets manually:
+
+```bash
+kubectl create secret docker-registry registry-creds \
+  --docker-server=<REGISTRY> \
+  --docker-username=<USERNAME> \
+  --docker-password=<PASSWORD> \
+  --namespace airbridge-control
+```
+
+Repeat for each namespace as required.

--- a/infra/bootstrap/kustomization.yaml
+++ b/infra/bootstrap/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+  - serviceaccounts.yaml
+  - rbac.yaml
+  - registry-creds.yaml

--- a/infra/bootstrap/namespaces.yaml
+++ b/infra/bootstrap/namespaces.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: airbridge-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: "latest"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: airbridge-control
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: "latest"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: airbridge-edge
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: "latest"

--- a/infra/bootstrap/rbac.yaml
+++ b/infra/bootstrap/rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: airbridge-control-plane
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: airbridge-control-plane
+subjects:
+- kind: ServiceAccount
+  name: control-plane
+  namespace: airbridge-control
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: airbridge-control-plane
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: airbridge-edge-worker
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "pods/exec"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: airbridge-edge-worker
+subjects:
+- kind: ServiceAccount
+  name: edge-worker
+  namespace: airbridge-edge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: airbridge-edge-worker

--- a/infra/bootstrap/registry-creds.yaml
+++ b/infra/bootstrap/registry-creds.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-creds
+  namespace: airbridge-system
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: e30K
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-creds
+  namespace: airbridge-control
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: e30K
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-creds
+  namespace: airbridge-edge
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: e30K

--- a/infra/bootstrap/serviceaccounts.yaml
+++ b/infra/bootstrap/serviceaccounts.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: control-plane
+  namespace: airbridge-control
+imagePullSecrets:
+  - name: registry-creds
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: edge-worker
+  namespace: airbridge-edge
+imagePullSecrets:
+  - name: registry-creds


### PR DESCRIPTION
## Summary
- provide kustomize config for baseline namespaces
- add service accounts, RBAC, and registry credential secrets
- document bootstrap usage and secret creation

## Testing
- `kubectl kustomize infra/bootstrap`
- `pytest` *(fails: ModuleNotFoundError: No module named 'airflow')*

------
https://chatgpt.com/codex/tasks/task_e_68a1a6820b1c832cace9d6da00c811f6