### PR TITLE
feat: sync DAGs from S3

### DIFF
--- a/docs/dag-sync-sla.md
+++ b/docs/dag-sync-sla.md
@@ -1,0 +1,9 @@
+# DAG Sync SLA
+
+AirBridge synchronizes DAG definitions from an S3 bucket to the control plane's `DAGS_FOLDER` using a Kubernetes CronJob.
+The job runs `aws s3 sync` on a shared volume so Airflow components read DAG files locally, avoiding any direct S3 mounts.
+
+The CronJob executes every minute and skips overlapping runs (`concurrencyPolicy: Forbid`). If a sync fails, the job
+retries with exponential backoff. With the default schedule, new or updated DAGs propagate to the control plane within two
+minutes.
+

--- a/infra/helm/airbridge/templates/dag-sync-cronjob.yaml
+++ b/infra/helm/airbridge/templates/dag-sync-cronjob.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.dagSync.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "airbridge.fullname" . }}-dag-sync
+spec:
+  schedule: {{ .Values.dagSync.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: dag-sync
+            image: {{ .Values.dagSync.image }}
+            command: ["/bin/sh","-c"]
+            args:
+            - |
+              n=0
+              until aws s3 sync s3://{{ .Values.dagSync.bucket }}{{ if .Values.dagSync.prefix }}/{{ .Values.dagSync.prefix }}{{ end }} {{ .Values.dags.path }}; do
+                n=$((n+1))
+                sleep $((2**n))
+                if [ $n -ge 5 ]; then
+                  exit 1
+                fi
+              done
+            volumeMounts:
+            - name: dags
+              mountPath: {{ .Values.dags.path }}
+          volumes:
+          - name: dags
+            persistentVolumeClaim:
+              claimName: {{ include "airbridge.fullname" . }}-dags
+{{- end }}

--- a/infra/helm/airbridge/templates/dags-pvc.yaml
+++ b/infra/helm/airbridge/templates/dags-pvc.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.dags.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "airbridge.fullname" . }}-dags
+spec:
+  accessModes:
+    - {{ .Values.dags.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.dags.persistence.size }}
+  storageClassName: {{ .Values.dags.persistence.storageClassName }}
+{{- end }}

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -40,7 +40,16 @@ spec:
         - name: airflow-config
           mountPath: /opt/airflow/airflow.cfg
           subPath: airflow.cfg
+{{- if .Values.dags.persistence.enabled }}
+        - name: dags
+          mountPath: {{ .Values.dags.path }}
+{{- end }}
       volumes:
       - name: airflow-config
         configMap:
           name: {{ include "airbridge.fullname" . }}-config
+{{- if .Values.dags.persistence.enabled }}
+      - name: dags
+        persistentVolumeClaim:
+          claimName: {{ include "airbridge.fullname" . }}-dags
+{{- end }}

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -40,7 +40,16 @@ spec:
         - name: airflow-config
           mountPath: /opt/airflow/airflow.cfg
           subPath: airflow.cfg
+{{- if .Values.dags.persistence.enabled }}
+        - name: dags
+          mountPath: {{ .Values.dags.path }}
+{{- end }}
       volumes:
       - name: airflow-config
         configMap:
           name: {{ include "airbridge.fullname" . }}-config
+{{- if .Values.dags.persistence.enabled }}
+      - name: dags
+        persistentVolumeClaim:
+          claimName: {{ include "airbridge.fullname" . }}-dags
+{{- end }}

--- a/infra/helm/airbridge/templates/webserver-deployment.yaml
+++ b/infra/helm/airbridge/templates/webserver-deployment.yaml
@@ -44,7 +44,16 @@ spec:
         - name: airflow-config
           mountPath: /opt/airflow/airflow.cfg
           subPath: airflow.cfg
+{{- if .Values.dags.persistence.enabled }}
+        - name: dags
+          mountPath: {{ .Values.dags.path }}
+{{- end }}
       volumes:
       - name: airflow-config
         configMap:
           name: {{ include "airbridge.fullname" . }}-config
+{{- if .Values.dags.persistence.enabled }}
+      - name: dags
+        persistentVolumeClaim:
+          claimName: {{ include "airbridge.fullname" . }}-dags
+{{- end }}

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -50,6 +50,13 @@ dags:
   gitSync:
     enabled: false
 
+dagSync:
+  enabled: false
+  bucket: ""
+  prefix: ""
+  schedule: "*/1 * * * *"
+  image: amazon/aws-cli:2.13.5
+
 airflow:
   executor: airflow.providers.edge3.executors.EdgeExecutor
   config: |

--- a/infra/helm/airbridge/values-prod.yaml
+++ b/infra/helm/airbridge/values-prod.yaml
@@ -22,3 +22,6 @@ ingress:
   tls:
     enabled: true
     secretName: prod-cert
+
+dagSync:
+  enabled: false

--- a/infra/helm/airbridge/values-stage.yaml
+++ b/infra/helm/airbridge/values-stage.yaml
@@ -16,3 +16,6 @@ ingress:
   tls:
     enabled: true
     secretName: stage-cert
+
+dagSync:
+  enabled: false

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -133,3 +133,10 @@ dags:
   # If you prefer pulling DAGs from git, enable this instead of (or in addition to) manual uploads.
   gitSync:
     enabled: false
+
+dagSync:
+  enabled: false
+  bucket: ""
+  prefix: ""
+  schedule: "*/1 * * * *"
+  image: amazon/aws-cli:2.13.5


### PR DESCRIPTION
## Summary
- add Kubernetes CronJob to sync DAGs from S3 to shared volume
- mount shared DAG volume in Airflow deployments
- document DAG sync SLA

## Testing
- `pytest` *(fails: tests/test_edge_executor_import.py, tests/test_edge_executor_pipeline.py, tests/test_edge_sample_dag.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b42c6e54832c81c99dd9d2f8593c