### PR TITLE
feat: add optional dag sync sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # AirBridge
 Build a control-plane/data-plane Airflow on 3.0.4 using Edge Executor. Control plane hosts web/API, scheduler, triggerer, DB; data planes run lightweight edge workers with outbound-only HTTPS. DAGs and logs are centralized in S3.
 
+The Helm chart optionally synchronizes DAGs from S3 to the cluster using either a
+`CronJob` or a sidecar container controlled by `.Values.dagSync` settings.
+
 ## Building and Testing
 
 The control-plane services (webserver, scheduler, and triggerer) are built as Docker images. Use the Makefile to build all three:

--- a/docs/control-plane-config.md
+++ b/docs/control-plane-config.md
@@ -39,3 +39,26 @@ can be provided in `ingress.waf.securityPolicy`.
 Expose a health check endpoint with `ingress.healthCheckPath` and ensure your
 monitoring system tracks 4xx and 5xx response rates for early detection of
 problems.
+
+## Synchronizing DAGs from S3
+
+AirBridge can automatically pull DAG files from an S3 bucket either using a
+Kubernetes `CronJob` or a sidecar container deployed alongside the scheduler,
+webserver and triggerer pods.
+
+Enable synchronization by setting `dagSync.enabled` to `true` and specifying the
+S3 `bucket` (and optional `prefix`). Choose between `dagSync.mode` of `cronjob`
+or `sidecar`:
+
+- **CronJob** – runs on the schedule defined by `dagSync.schedule`. Retries are
+  controlled through `dagSync.backoffLimit` and the `retries` value used by the
+  sync script.
+- **Sidecar** – runs continuously with a sleep interval of
+  `dagSync.intervalSeconds` between successful syncs. Consecutive failures follow
+  exponential backoff up to `dagSync.retries` attempts before the container
+  restarts.
+
+The sync container uses the AWS CLI and relies on cloud credentials made
+available to the pod. In cloud environments, configure IAM Roles for Service
+Accounts (IRSA) or an equivalent mechanism so the pod's service account can read
+from the target S3 bucket without embedding static credentials.

--- a/infra/helm/airbridge/templates/_helpers.tpl
+++ b/infra/helm/airbridge/templates/_helpers.tpl
@@ -1,3 +1,28 @@
 {{- define "airbridge.fullname" -}}
 {{- .Release.Name -}}
 {{- end -}}
+
+{{/* Dag sync sidecar container */}}
+{{- define "airbridge.dagSync.container" -}}
+- name: dag-sync
+  image: {{ .Values.dagSync.image }}
+  command: ["/bin/sh","-c"]
+  args:
+    - |
+      n=0
+      while true; do
+        if aws s3 sync s3://{{ .Values.dagSync.bucket }}{{ if .Values.dagSync.prefix }}/{{ .Values.dagSync.prefix }}{{ end }} {{ .Values.dags.path }}; then
+          n=0
+          sleep {{ .Values.dagSync.intervalSeconds }}
+        else
+          n=$((n+1))
+          sleep $((2**n))
+          if [ $n -ge {{ .Values.dagSync.retries }} ]; then
+            exit 1
+          fi
+        fi
+      done
+  volumeMounts:
+    - name: dags
+      mountPath: {{ .Values.dags.path }}
+{{- end -}}

--- a/infra/helm/airbridge/templates/dag-sync-cronjob.yaml
+++ b/infra/helm/airbridge/templates/dag-sync-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.dagSync.enabled }}
+{{- if and .Values.dagSync.enabled (eq .Values.dagSync.mode "cronjob") }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -8,7 +8,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      backoffLimit: 3
+      backoffLimit: {{ .Values.dagSync.backoffLimit }}
       template:
         spec:
           restartPolicy: OnFailure
@@ -22,7 +22,7 @@ spec:
               until aws s3 sync s3://{{ .Values.dagSync.bucket }}{{ if .Values.dagSync.prefix }}/{{ .Values.dagSync.prefix }}{{ end }} {{ .Values.dags.path }}; do
                 n=$((n+1))
                 sleep $((2**n))
-                if [ $n -ge 5 ]; then
+                if [ $n -ge {{ .Values.dagSync.retries }} ]; then
                   exit 1
                 fi
               done

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - name: dags
           mountPath: {{ .Values.dags.path }}
 {{- end }}
+{{- if and .Values.dagSync.enabled (eq .Values.dagSync.mode "sidecar") }}
+{{ include "airbridge.dagSync.container" . | indent 6 }}
+{{- end }}
       volumes:
       - name: airflow-config
         configMap:

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - name: dags
           mountPath: {{ .Values.dags.path }}
 {{- end }}
+{{- if and .Values.dagSync.enabled (eq .Values.dagSync.mode "sidecar") }}
+{{ include "airbridge.dagSync.container" . | indent 6 }}
+{{- end }}
       volumes:
       - name: airflow-config
         configMap:

--- a/infra/helm/airbridge/templates/webserver-deployment.yaml
+++ b/infra/helm/airbridge/templates/webserver-deployment.yaml
@@ -48,6 +48,9 @@ spec:
         - name: dags
           mountPath: {{ .Values.dags.path }}
 {{- end }}
+{{- if and .Values.dagSync.enabled (eq .Values.dagSync.mode "sidecar") }}
+{{ include "airbridge.dagSync.container" . | indent 6 }}
+{{- end }}
       volumes:
       - name: airflow-config
         configMap:

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -54,8 +54,12 @@ dagSync:
   enabled: false
   bucket: ""
   prefix: ""
-  schedule: "*/1 * * * *"
   image: amazon/aws-cli:2.13.5
+  mode: cronjob   # cronjob or sidecar
+  schedule: "*/1 * * * *"
+  intervalSeconds: 60
+  backoffLimit: 3
+  retries: 5
 
 airflow:
   executor: airflow.providers.edge3.executors.EdgeExecutor

--- a/infra/helm/airbridge/values-prod.yaml
+++ b/infra/helm/airbridge/values-prod.yaml
@@ -25,3 +25,11 @@ ingress:
 
 dagSync:
   enabled: false
+  bucket: ""
+  prefix: ""
+  image: amazon/aws-cli:2.13.5
+  mode: cronjob
+  schedule: "*/1 * * * *"
+  intervalSeconds: 60
+  backoffLimit: 3
+  retries: 5

--- a/infra/helm/airbridge/values-stage.yaml
+++ b/infra/helm/airbridge/values-stage.yaml
@@ -19,3 +19,11 @@ ingress:
 
 dagSync:
   enabled: false
+  bucket: ""
+  prefix: ""
+  image: amazon/aws-cli:2.13.5
+  mode: cronjob
+  schedule: "*/1 * * * *"
+  intervalSeconds: 60
+  backoffLimit: 3
+  retries: 5

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -143,5 +143,9 @@ dagSync:
   enabled: false
   bucket: ""
   prefix: ""
-  schedule: "*/1 * * * *"
   image: amazon/aws-cli:2.13.5
+  mode: cronjob   # cronjob or sidecar
+  schedule: "*/1 * * * *"
+  intervalSeconds: 60
+  backoffLimit: 3
+  retries: 5


### PR DESCRIPTION
## Summary
- allow syncing DAGs from S3 via CronJob or sidecar
- expose interval and backoff settings for `aws s3 sync`
- document IAM/IRSA guidance for DAG syncing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1fc6deef8832caf687e5dc3253531