### PR TITLE
Add edge worker Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build-webserver build-scheduler build-triggerer build-control-plane kind-up kind-down
+.PHONY: build-webserver build-scheduler build-triggerer build-control-plane build-edge-worker kind-up kind-down
 
 KIND_CLUSTER_NAME ?= airbridge
 HELM_RELEASE ?= airbridge-control-plane
@@ -16,6 +16,9 @@ build-triggerer:
 	docker build -t airbridge-triggerer:3.0.4 -f control-plane/triggerer/Dockerfile control-plane
 
 build-control-plane: build-webserver build-scheduler build-triggerer
+
+build-edge-worker:
+	docker build -t airbridge-edge-worker:3.0.4 -f data-plane/worker/Dockerfile data-plane
 
 kind-up: build-control-plane
 	kind create cluster --name $(KIND_CLUSTER_NAME)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ make build-control-plane
 
 Each image runs an entrypoint that performs `airflow db migrate` before starting the service. The CI workflow builds these images and verifies that the Airflow CLI is available to prevent regressions.
 
+A minimal edge-worker image is also provided:
+
+```
+make build-edge-worker
+```
+
+The worker runs as a non-root user, accepts configuration via environment variables (including `CONTROL_PLANE_TOKEN` or `CONTROL_PLANE_TOKEN_FILE` for token injection), and ships with a `diag` script to test connectivity to the control-plane API.
+
 ## Edge sample DAG
 
 An example DAG demonstrating the **EdgeExecutor** is provided in

--- a/data-plane/worker/Dockerfile
+++ b/data-plane/worker/Dockerfile
@@ -1,0 +1,30 @@
+FROM python:3.11-slim
+
+ENV AIRFLOW_HOME=/opt/airflow \
+    AIRFLOW_VERSION=3.0.4 \
+    PY_VER=3.11 \
+    PATH="${AIRFLOW_HOME}/.local/bin:${PATH}" \
+    CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PY_VER}.txt"
+
+# Install curl and create non-root user
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 50000 airflow \
+    && useradd --uid 50000 --gid airflow --home-dir ${AIRFLOW_HOME} --create-home airflow
+
+USER airflow
+WORKDIR ${AIRFLOW_HOME}
+
+# Install Airflow and providers
+COPY requirements.lock requirements.lock
+RUN pip install --no-cache-dir -r requirements.lock --constraint "${CONSTRAINT_URL}"
+
+COPY worker/entrypoint.sh /entrypoint.sh
+COPY worker/diag.sh /usr/local/bin/diag
+
+ENTRYPOINT ["/entrypoint.sh", "airflow"]
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl --fail "${CONTROL_PLANE_URL:-http://localhost:8080}/health" || exit 1
+
+CMD ["edge-worker"]

--- a/data-plane/worker/diag.sh
+++ b/data-plane/worker/diag.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ -z "${CONTROL_PLANE_URL:-}" ]; then
+  echo "CONTROL_PLANE_URL not set" >&2
+  exit 1
+fi
+
+curl -sv -H "Authorization: Bearer ${CONTROL_PLANE_TOKEN:-}" "${CONTROL_PLANE_URL}/health"

--- a/data-plane/worker/entrypoint.sh
+++ b/data-plane/worker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Inject token from file if provided
+if [ -n "${CONTROL_PLANE_TOKEN_FILE:-}" ] && [ -f "${CONTROL_PLANE_TOKEN_FILE}" ]; then
+  export CONTROL_PLANE_TOKEN="$(cat "${CONTROL_PLANE_TOKEN_FILE}")"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add minimal non-root edge worker image with healthcheck and diag tooling
- support token injection via environment and file
- document and provide Makefile target for building edge worker

## Testing
- `pytest`
- ⚠️ `make build-edge-worker` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ff509378832ca70773d55fee5911