### PR TITLE
Add edge DAG sync utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 Build a control-plane/data-plane Airflow on 3.0.4 using Edge Executor. Control plane hosts web/API, scheduler, triggerer, DB; data planes run lightweight edge workers with outbound-only HTTPS. DAGs and logs are centralized in S3.
 
 The Helm chart optionally synchronizes DAGs from S3 to the cluster using either a
-`CronJob` or a sidecar container controlled by `.Values.dagSync` settings.
+`CronJob` or a sidecar container controlled by `.Values.dagSync` settings. Edge
+workers can mirror the same bucket by running the `edge-dag-sync.sh` helper or
+deploying the sample CronJob in `infra/edge`.
 
 ## Building and Testing
 

--- a/docs/edge-dag-sync.md
+++ b/docs/edge-dag-sync.md
@@ -1,0 +1,34 @@
+# Edge DAG Synchronization
+
+Edge workers require local copies of DAG files identical to those in the control plane. Use an S3 sync job or sidecar to mirror the control plane's DAG bucket onto each edge node.
+
+## Sidecar container
+
+Run the provided `edge-dag-sync.sh` script in a companion container alongside the edge worker. The script continuously executes `aws s3 sync` with exponential backoff and verifies file integrity via checksums:
+
+```bash
+# example Docker invocation
+DAG_BUCKET=my-dag-bucket \
+DAGS_FOLDER=/opt/airflow/dags \
+docker run --rm -e DAG_BUCKET -e DAGS_FOLDER \
+  -v /opt/airflow/dags:/opt/airflow/dags \
+  amazon/aws-cli:2.13.5 /edge-dag-sync.sh
+```
+
+Environment variables:
+
+- `DAG_BUCKET` – S3 bucket containing DAGs (required)
+- `DAG_PREFIX` – optional prefix within the bucket
+- `DAGS_FOLDER` – local destination, defaults to `/opt/airflow/dags`
+- `INTERVAL_SECONDS` – sleep interval after successful sync (default 60)
+- `RETRIES` – maximum consecutive failures before exit (default 5)
+
+## Kubernetes CronJob
+
+For periodic one-off syncs, deploy `infra/edge/dag-sync-cronjob.yaml`. It runs `aws s3 sync --checksum --delete` once per minute and retries with exponential backoff on failure. Mount the same volume as the edge worker so both see identical DAG files.
+
+## IAM
+
+Grant the sync container read access to the DAG bucket (`s3:ListBucket` and `s3:GetObject`). In cloud environments, prefer attaching an IAM role to the pod or node rather than baking static credentials into the image. If a different account hosts the bucket, configure role assumption with `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` or similar mechanisms.
+
+With the sync job or sidecar in place, edge nodes maintain the same DAG set as the control plane and transient network outages trigger retries with increasing delays.

--- a/edge-dag-sync.sh
+++ b/edge-dag-sync.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DAG_BUCKET:?DAG_BUCKET must be set}"
+DAGS_FOLDER="${DAGS_FOLDER:-/opt/airflow/dags}"
+DAG_PREFIX="${DAG_PREFIX:-}"
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-60}"
+RETRIES="${RETRIES:-5}"
+
+n=0
+while true; do
+  if aws s3 sync --checksum --delete "s3://${DAG_BUCKET}${DAG_PREFIX:+/${DAG_PREFIX}}" "$DAGS_FOLDER"; then
+    n=0
+    sleep "$INTERVAL_SECONDS"
+  else
+    n=$((n+1))
+    sleep $((2**n))
+    if [ "$n" -ge "$RETRIES" ]; then
+      echo "DAG sync failed after $RETRIES attempts" >&2
+      exit 1
+    fi
+  fi
+done

--- a/infra/edge/dag-sync-cronjob.yaml
+++ b/infra/edge/dag-sync-cronjob.yaml
@@ -1,0 +1,41 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: edge-dag-sync
+  namespace: airbridge-edge
+spec:
+  schedule: "*/1 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          serviceAccountName: edge-worker
+          restartPolicy: OnFailure
+          containers:
+          - name: dag-sync
+            image: amazon/aws-cli:2.13.5
+            env:
+            - name: DAG_BUCKET
+              value: my-dag-bucket
+            - name: DAGS_FOLDER
+              value: /opt/airflow/dags
+            command: ["/bin/sh","-c"]
+            args:
+            - |
+              n=0
+              until aws s3 sync --checksum --delete s3://$DAG_BUCKET $DAGS_FOLDER; do
+                n=$((n+1))
+                sleep $((2**n))
+                if [ $n -ge 5 ]; then
+                  exit 1
+                fi
+              done
+            volumeMounts:
+            - name: dags
+              mountPath: /opt/airflow/dags
+          volumes:
+          - name: dags
+            persistentVolumeClaim:
+              claimName: edge-dags


### PR DESCRIPTION
## Summary
- provide `edge-dag-sync.sh` helper to mirror DAGs from S3 onto edge nodes
- document edge DAG synchronization with sidecar and CronJob examples
- include sample CronJob manifest for edge DAG syncing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a204476c68832c9a263cda9cbc7090