### PR TITLE
Add Helm chart for edge worker

### DIFF
--- a/docs/deploy/helm-edge-worker.md
+++ b/docs/deploy/helm-edge-worker.md
@@ -1,0 +1,60 @@
+# Deploy Edge Worker with Helm
+
+Install the AirBridge edge worker on a customer Kubernetes cluster using the provided Helm chart.
+
+## Prerequisites
+- Kubernetes cluster with network access to the control plane
+- Secret containing a control plane token
+- Helm 3 installed
+
+## Installation
+
+```bash
+helm install my-worker infra/helm/edge-worker \
+  --set queue=my-queue \
+  --set controlPlane.url=https://cp.example.com \
+  --set controlPlane.tokenSecret.name=edge-token \
+  --set controlPlane.tokenSecret.key=token
+```
+
+The `queue` value binds the worker to a specific execution queue. Update the `controlPlane` settings to match your environment.
+
+## Deployment Mode
+
+The chart runs as a `Deployment` by default. To run a worker on every node, set:
+
+```bash
+--set mode=daemonset
+```
+
+## Metrics
+
+Enable Prometheus metrics with:
+
+```bash
+--set metrics.enabled=true
+```
+
+A `ServiceMonitor` can be created for scraping by setting:
+
+```bash
+--set metrics.enabled=true --set metrics.serviceMonitor.enabled=true
+```
+
+## Tenant Values Example
+
+An example values file demonstrating tenant-scoped configuration is available at `infra/helm/edge-worker/values-tenant.yaml`.
+
+```bash
+helm install tenant-a infra/helm/edge-worker -f infra/helm/edge-worker/values-tenant.yaml
+```
+
+## Verification
+
+After installation, verify the worker is ready:
+
+```bash
+kubectl get pods
+```
+
+The pod should register with the control plane and heartbeat successfully.

--- a/infra/helm/edge-worker/Chart.yaml
+++ b/infra/helm/edge-worker/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: airbridge-edge-worker
+description: Helm chart for deploying AirBridge edge workers
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/infra/helm/edge-worker/templates/_helpers.tpl
+++ b/infra/helm/edge-worker/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "edge-worker.fullname" -}}
+{{- .Release.Name -}}
+{{- end -}}

--- a/infra/helm/edge-worker/templates/edge-worker.yaml
+++ b/infra/helm/edge-worker/templates/edge-worker.yaml
@@ -1,0 +1,78 @@
+{{- if eq (lower .Values.mode) "daemonset" }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "edge-worker.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+    spec:
+      containers:
+        - name: edge-worker
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bootstrap-edge.sh"]
+          args:
+            - "--queue"
+            - {{ .Values.queue | quote }}
+            {{- if .Values.metrics.enabled }}
+            - "--metrics-port"
+            - {{ .Values.metrics.port | quote }}
+            {{- end }}
+          env:
+            - name: CONTROL_PLANE_URL
+              value: {{ .Values.controlPlane.url | quote }}
+            - name: CONTROL_PLANE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.controlPlane.tokenSecret.name }}
+                  key: {{ .Values.controlPlane.tokenSecret.key }}
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}
+{{- else }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "edge-worker.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+    spec:
+      containers:
+        - name: edge-worker
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bootstrap-edge.sh"]
+          args:
+            - "--queue"
+            - {{ .Values.queue | quote }}
+            {{- if .Values.metrics.enabled }}
+            - "--metrics-port"
+            - {{ .Values.metrics.port | quote }}
+            {{- end }}
+          env:
+            - name: CONTROL_PLANE_URL
+              value: {{ .Values.controlPlane.url | quote }}
+            - name: CONTROL_PLANE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.controlPlane.tokenSecret.name }}
+                  key: {{ .Values.controlPlane.tokenSecret.key }}
+          resources:
+{{- toYaml .Values.resources | nindent 12 }}
+{{- end }}

--- a/infra/helm/edge-worker/templates/service.yaml
+++ b/infra/helm/edge-worker/templates/service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "edge-worker.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+spec:
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: {{ .Values.metrics.port }}
+  selector:
+    app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+{{- end }}

--- a/infra/helm/edge-worker/templates/servicemonitor.yaml
+++ b/infra/helm/edge-worker/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "edge-worker.fullname" . }}
+  labels:
+{{- range $k,$v := .Values.metrics.serviceMonitor.additionalLabels }}
+    {{ $k }}: {{ $v | quote }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "edge-worker.fullname" . }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/infra/helm/edge-worker/values-tenant.yaml
+++ b/infra/helm/edge-worker/values-tenant.yaml
@@ -1,0 +1,19 @@
+mode: daemonset
+queue: tenant-a
+controlPlane:
+  url: https://cp.example.com
+  tokenSecret:
+    name: tenant-a-edge-token
+    key: token
+metrics:
+  enabled: true
+  port: 9102
+  serviceMonitor:
+    enabled: true
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/infra/helm/edge-worker/values.yaml
+++ b/infra/helm/edge-worker/values.yaml
@@ -1,0 +1,20 @@
+mode: deployment  # deployment or daemonset
+replicaCount: 1
+image:
+  repository: airbridge/edge-worker
+  tag: latest
+  pullPolicy: IfNotPresent
+queue: default
+controlPlane:
+  url: https://control-plane.example.com
+  tokenSecret:
+    name: edge-worker-token
+    key: token
+resources: {}
+metrics:
+  enabled: false
+  port: 9102
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    additionalLabels: {}


### PR DESCRIPTION
## Summary
- package edge worker as Helm chart with selectable Deployment or DaemonSet modes
- expose configuration for control-plane URL, token secret, queue binding, resources and optional ServiceMonitor
- document installation and provide tenant values example

## Testing
- `helm lint infra/helm/edge-worker`
- `helm template test infra/helm/edge-worker -f infra/helm/edge-worker/values-tenant.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68a20b08c884832c9436b0b5ee7c5bcf