### PR TITLE
Centralize secrets in AWS Secrets Manager

### DIFF
--- a/control-plane/airflow.cfg
+++ b/control-plane/airflow.cfg
@@ -3,8 +3,12 @@
 # ensures Airflow can import the executor when the configuration is loaded.
 executor = airflow.providers.edge3.executors.EdgeExecutor
 
-# Edge API enabled via environment variables; token provided through
-# the EDGE_API_TOKEN environment variable.
+[secrets]
+backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
+backend_kwargs = {"connections_prefix": "airflow/connections", "variables_prefix": "airflow/variables", "config_prefix": "airflow/config"}
+
+# Edge API token is provided via the EDGE_API_TOKEN environment variable.
+# The value is pulled from AWS Secrets Manager at container start.
 [edge]
 api_enabled = True
 api_url = https://localhost:8080/edge_worker/v1/rpcapi
@@ -16,4 +20,4 @@ remote_base_log_folder = s3://airbridge-logs/logs
 delete_local_logs = True
 
 [api_auth]
-jwt_secret = dgdgfdfdgfdgh
+jwt_secret = ${JWT_SECRET}

--- a/control-plane/scripts/entrypoint.sh
+++ b/control-plane/scripts/entrypoint.sh
@@ -3,6 +3,30 @@ set -euo pipefail
 
 : "${AIRFLOW_HOME:=/opt/airflow}"
 
+# Load secrets from AWS Secrets Manager if secret IDs are provided
+if [ -n "${JWT_SECRET_ID:-}" ] || [ -n "${EDGE_API_TOKEN_ID:-}" ]; then
+  eval "$(
+    python <<'PY'
+import os, shlex
+try:
+    import boto3
+except Exception:
+    raise SystemExit
+client = boto3.client('secretsmanager', region_name=os.getenv('AWS_REGION'))
+mapping = {'JWT_SECRET_ID': 'JWT_SECRET', 'EDGE_API_TOKEN_ID': 'EDGE_API_TOKEN'}
+for env_id, env_var in mapping.items():
+    secret_id = os.getenv(env_id)
+    if not secret_id:
+        continue
+    try:
+        value = client.get_secret_value(SecretId=secret_id)['SecretString']
+        print(f"export {env_var}={shlex.quote(value)}")
+    except Exception:
+        pass
+PY
+  )"
+fi
+
 # Initialize database if needed
 airflow db migrate
 

--- a/data-plane/worker/entrypoint.sh
+++ b/data-plane/worker/entrypoint.sh
@@ -6,4 +6,18 @@ if [ -n "${CONTROL_PLANE_TOKEN_FILE:-}" ] && [ -f "${CONTROL_PLANE_TOKEN_FILE}" 
   export CONTROL_PLANE_TOKEN="$(cat "${CONTROL_PLANE_TOKEN_FILE}")"
 fi
 
+# Fetch token from AWS Secrets Manager if an ID is provided
+if [ -n "${CONTROL_PLANE_TOKEN_ID:-}" ]; then
+  CONTROL_PLANE_TOKEN="$(python - <<'PY'
+import os
+try:
+    import boto3
+except Exception:
+    raise SystemExit
+client = boto3.client('secretsmanager', region_name=os.getenv('AWS_REGION'))
+print(client.get_secret_value(SecretId=os.environ['CONTROL_PLANE_TOKEN_ID'])['SecretString'])
+PY
+  )" && export CONTROL_PLANE_TOKEN
+fi
+
 exec "$@"

--- a/docs/control-plane-config.md
+++ b/docs/control-plane-config.md
@@ -5,20 +5,18 @@ Key settings include:
 
 - `[core] executor = edge_executor.EdgeExecutor`
 - Edge API enabled so edge workers can communicate with the control plane.
-- Token based authentication for the Edge API; tokens are supplied via environment variables.
+- Token based authentication for the Edge API; tokens are sourced from AWS Secrets Manager and injected as environment variables.
 - Remote task logs written to S3 under `s3://<project>-logs/logs` with local logs deleted after upload.
 - Requires the `apache-airflow-providers-amazon` package for S3 logging support.
 
 ## Enabling the Edge API
 
-1. Create a Kubernetes secret containing the token:
-   ```bash
-   kubectl create secret generic edge-api-token --from-literal=token=<token>
-   ```
-2. Set `.Values.edgeApi.enabled` to `true` and provide the secret name via
-   `.Values.edgeApi.tokenSecretName` in the Helm chart values.
-3. The webserver deployment reads the token from the secret and exposes it to
-   Airflow via the `EDGE_API_TOKEN` environment variable.
+1. Store the token in AWS Secrets Manager and note the secret ID.
+2. Set `.Values.edgeApi.enabled` to `true` and provide the secret ID via
+   `.Values.edgeApi.tokenSecretId` in the Helm chart values.
+3. The webserver deployment receives the secret ID as `EDGE_API_TOKEN_ID` and
+   `entrypoint.sh` fetches the token at startup, exposing it to Airflow through
+   the `EDGE_API_TOKEN` environment variable.
 
 With these settings the scheduler runs using the `EdgeExecutor` and the webserver
 exposes the authenticated Edge API.

--- a/docs/deploy/helm-edge-worker.md
+++ b/docs/deploy/helm-edge-worker.md
@@ -5,7 +5,7 @@ Install the AirBridge edge worker on a customer Kubernetes cluster using the pro
 ## Prerequisites
 - Kubernetes cluster with outbound HTTPS access to the control-plane API (port 443). Workers may sit behind NAT or egress-only firewalls.
 - No inbound firewall rules are required; the worker initiates all connections.
-- Secret containing a control plane token
+- Control plane token stored in AWS Secrets Manager
 - Helm 3 installed
 
 ## Installation
@@ -14,8 +14,7 @@ Install the AirBridge edge worker on a customer Kubernetes cluster using the pro
 helm install my-worker infra/helm/edge-worker \
   --set queue=my-queue \
   --set controlPlane.url=https://cp.example.com \
-  --set controlPlane.tokenSecret.name=edge-token \
-  --set controlPlane.tokenSecret.key=token
+  --set controlPlane.tokenSecretId=edge-token-id
 ```
 
 The `queue` value binds the worker to a specific execution queue. Update the `controlPlane` settings to match your environment.

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -1,0 +1,27 @@
+# Secrets Management
+
+This project stores tokens, Airflow connections, and configuration values in AWS Secrets Manager. The Airflow images fetch secrets at startup using the secret identifiers provided through environment variables.
+
+## Storing secrets
+
+1. Create secrets in AWS Secrets Manager. Recommended names:
+   - `airflow/connections/<name>` for Airflow connections.
+   - `airflow/config/api_auth__jwt_secret` for the webserver JWT secret.
+   - `edge-api-token` for the edge API token.
+2. Grant the control-plane and edge worker IAM roles permission to `secretsmanager:GetSecretValue`.
+3. Provide the secret IDs to pods:
+   - set `edgeApi.tokenSecretId` in the Helm chart values.
+   - optionally set `controlPlane.tokenSecretId` for edge workers.
+   - define `JWT_SECRET_ID` in the control-plane environment.
+
+At container startup, `entrypoint.sh` retrieves each secret and exports the expected environment variables (`EDGE_API_TOKEN`, `CONTROL_PLANE_TOKEN`, `JWT_SECRET`).
+
+## Rotation
+
+Use AWS Secrets Manager rotation to replace tokens on a fixed schedule. For static tokens, rotate at least every 90 days. To verify rotation:
+
+1. Update the secret value in AWS Secrets Manager.
+2. Restart the affected pods.
+3. Confirm they reload the new secret and continue functioning.
+
+Avoid committing plaintext secrets to this repository or embedding them into container images. All sensitive values should live exclusively in AWS Secrets Manager.

--- a/infra/helm/airbridge/templates/flower-deployment.yaml
+++ b/infra/helm/airbridge/templates/flower-deployment.yaml
@@ -23,11 +23,17 @@ spec:
           value: {{ .Values.airflow.executor | quote }}
         - name: AIRFLOW__API__EDGE__ENABLED
           value: {{ .Values.edgeApi.enabled | quote }}
+{{- if .Values.edgeApi.tokenSecretName }}
         - name: EDGE_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Values.edgeApi.tokenSecretName }}
               key: token
+{{- end }}
+{{- if .Values.edgeApi.tokenSecretId }}
+        - name: EDGE_API_TOKEN_ID
+          value: {{ .Values.edgeApi.tokenSecretId | quote }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.flower.service.port }}
         livenessProbe:

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -21,11 +21,17 @@ spec:
           value: {{ .Values.airflow.executor | quote }}
         - name: AIRFLOW__API__EDGE__ENABLED
           value: {{ .Values.edgeApi.enabled | quote }}
+{{- if .Values.edgeApi.tokenSecretName }}
         - name: EDGE_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Values.edgeApi.tokenSecretName }}
               key: token
+{{- end }}
+{{- if .Values.edgeApi.tokenSecretId }}
+        - name: EDGE_API_TOKEN_ID
+          value: {{ .Values.edgeApi.tokenSecretId | quote }}
+{{- end }}
         livenessProbe:
           exec:
             command: ["bash", "-c", "airflow jobs check scheduler"]

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -21,11 +21,17 @@ spec:
           value: {{ .Values.airflow.executor | quote }}
         - name: AIRFLOW__API__EDGE__ENABLED
           value: {{ .Values.edgeApi.enabled | quote }}
+{{- if .Values.edgeApi.tokenSecretName }}
         - name: EDGE_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Values.edgeApi.tokenSecretName }}
               key: token
+{{- end }}
+{{- if .Values.edgeApi.tokenSecretId }}
+        - name: EDGE_API_TOKEN_ID
+          value: {{ .Values.edgeApi.tokenSecretId | quote }}
+{{- end }}
         livenessProbe:
           exec:
             command: ["bash", "-c", "airflow jobs check triggerer"]

--- a/infra/helm/airbridge/templates/webserver-deployment.yaml
+++ b/infra/helm/airbridge/templates/webserver-deployment.yaml
@@ -21,11 +21,17 @@ spec:
           value: {{ .Values.airflow.executor | quote }}
         - name: AIRFLOW__API__EDGE__ENABLED
           value: {{ .Values.edgeApi.enabled | quote }}
+{{- if .Values.edgeApi.tokenSecretName }}
         - name: EDGE_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: {{ .Values.edgeApi.tokenSecretName }}
               key: token
+{{- end }}
+{{- if .Values.edgeApi.tokenSecretId }}
+        - name: EDGE_API_TOKEN_ID
+          value: {{ .Values.edgeApi.tokenSecretId | quote }}
+{{- end }}
         ports:
         - containerPort: {{ .Values.webserver.service.port }}
         livenessProbe:

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -29,8 +29,9 @@ flower:
 edgeApi:
   enabled: true
   tokenSecretName: edge-api-token
-  createSecret: true
-  token: dev-token
+  tokenSecretId: ""
+  createSecret: false
+  token: ""
 
 ingress:
   enabled: true
@@ -72,4 +73,4 @@ airflow:
     remote_base_log_folder = s3://airbridge-logs/logs
     delete_local_logs = True
     [api_auth]
-    jwt_secret = dev-jwt-secret
+    jwt_secret = ${JWT_SECRET}

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -84,6 +84,7 @@ flower:
 edgeApi:
   enabled: true
   tokenSecretName: edge-api-token
+  tokenSecretId: ""
   createSecret: false
   token: ""
 
@@ -118,7 +119,7 @@ airflow:
     remote_base_log_folder = s3://airbridge-logs/logs
     delete_local_logs = True
     [api_auth]
-    jwt_secret = change_me
+    jwt_secret = ${JWT_SECRET}
 
 # DAG volume and git sync configurations are unchanged
 # from previous chart versions.

--- a/infra/helm/edge-worker/templates/edge-worker.yaml
+++ b/infra/helm/edge-worker/templates/edge-worker.yaml
@@ -29,11 +29,17 @@ spec:
           env:
             - name: CONTROL_PLANE_URL
               value: {{ .Values.controlPlane.url | quote }}
+{{- if .Values.controlPlane.tokenSecret.name }}
             - name: CONTROL_PLANE_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.controlPlane.tokenSecret.name }}
                   key: {{ .Values.controlPlane.tokenSecret.key }}
+{{- end }}
+{{- if .Values.controlPlane.tokenSecretId }}
+            - name: CONTROL_PLANE_TOKEN_ID
+              value: {{ .Values.controlPlane.tokenSecretId | quote }}
+{{- end }}
           resources:
 {{- toYaml .Values.resources | nindent 12 }}
 {{- else }}
@@ -68,11 +74,17 @@ spec:
           env:
             - name: CONTROL_PLANE_URL
               value: {{ .Values.controlPlane.url | quote }}
+{{- if .Values.controlPlane.tokenSecret.name }}
             - name: CONTROL_PLANE_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.controlPlane.tokenSecret.name }}
                   key: {{ .Values.controlPlane.tokenSecret.key }}
+{{- end }}
+{{- if .Values.controlPlane.tokenSecretId }}
+            - name: CONTROL_PLANE_TOKEN_ID
+              value: {{ .Values.controlPlane.tokenSecretId | quote }}
+{{- end }}
           resources:
 {{- toYaml .Values.resources | nindent 12 }}
 {{- end }}

--- a/infra/helm/edge-worker/values-tenant.yaml
+++ b/infra/helm/edge-worker/values-tenant.yaml
@@ -5,6 +5,7 @@ controlPlane:
   tokenSecret:
     name: tenant-a-edge-token
     key: token
+  tokenSecretId: ""
 metrics:
   enabled: true
   port: 9102

--- a/infra/helm/edge-worker/values.yaml
+++ b/infra/helm/edge-worker/values.yaml
@@ -10,6 +10,7 @@ controlPlane:
   tokenSecret:
     name: edge-worker-token
     key: token
+  tokenSecretId: ""
 resources: {}
 metrics:
   enabled: false


### PR DESCRIPTION
## Summary
- configure Airflow to use AWS Secrets Manager and remove plaintext JWT secret
- load edge API and control-plane tokens from Secrets Manager at container startup
- document secret storage and rotation procedures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2143b4b64832c97ebd8f5301f056f