### PR TITLE
Add shared Postgres database for Airflow components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,17 @@ run-edge-worker: build-edge-worker
 	docker run --rm airbridge-edge-worker:3.0.4
 
 minikube-up: build-control-plane
-	minikube start -p $(MINIKUBE_PROFILE)
-	minikube image load -p $(MINIKUBE_PROFILE) airbridge-webserver:3.0.4
-	minikube image load -p $(MINIKUBE_PROFILE) airbridge-scheduler:3.0.4
-	minikube image load -p $(MINIKUBE_PROFILE) airbridge-triggerer:3.0.4
-	helm upgrade --install $(HELM_RELEASE) infra/helm/airbridge -f $(HELM_VALUES)
-	
-	kubectl --context $(MINIKUBE_PROFILE) wait --for=condition=Ready pod -l app=$(HELM_RELEASE)-webserver --timeout=180s
-	WEB_POD=$$(kubectl --context $(MINIKUBE_PROFILE) get pods -l app=$(HELM_RELEASE)-webserver -o jsonpath='{.items[0].metadata.name}') && \
-	kubectl --context $(MINIKUBE_PROFILE) cp control-plane/dags/. $$WEB_POD:/opt/airflow/dags
+        minikube start -p $(MINIKUBE_PROFILE)
+        minikube image load -p $(MINIKUBE_PROFILE) airbridge-webserver:3.0.4
+        minikube image load -p $(MINIKUBE_PROFILE) airbridge-scheduler:3.0.4
+        minikube image load -p $(MINIKUBE_PROFILE) airbridge-triggerer:3.0.4
+        minikube image load -p $(MINIKUBE_PROFILE) postgres:15
+        helm upgrade --install $(HELM_RELEASE) infra/helm/airbridge -f $(HELM_VALUES)
+
+        kubectl --context $(MINIKUBE_PROFILE) wait --for=condition=Ready pod -l app=$(HELM_RELEASE)-postgres --timeout=180s
+        kubectl --context $(MINIKUBE_PROFILE) wait --for=condition=Ready pod -l app=$(HELM_RELEASE)-webserver --timeout=180s
+        WEB_POD=$$(kubectl --context $(MINIKUBE_PROFILE) get pods -l app=$(HELM_RELEASE)-webserver -o jsonpath='{.items[0].metadata.name}') && \
+        kubectl --context $(MINIKUBE_PROFILE) cp control-plane/dags/. $$WEB_POD:/opt/airflow/dags
 	
 	
 

--- a/infra/helm/airbridge/templates/postgres-deployment.yaml
+++ b/infra/helm/airbridge/templates/postgres-deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "airbridge.fullname" . }}-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "airbridge.fullname" . }}-postgres
+  template:
+    metadata:
+      labels:
+        app: {{ include "airbridge.fullname" . }}-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: "{{ .Values.postgres.image }}:{{ .Values.postgres.tag }}"
+        imagePullPolicy: {{ .Values.postgres.pullPolicy }}
+        env:
+        - name: POSTGRES_USER
+          value: {{ .Values.postgres.user | quote }}
+        - name: POSTGRES_PASSWORD
+          value: {{ .Values.postgres.password | quote }}
+        - name: POSTGRES_DB
+          value: {{ .Values.postgres.db | quote }}
+        ports:
+        - containerPort: {{ .Values.postgres.port }}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/infra/helm/airbridge/templates/postgres-service.yaml
+++ b/infra/helm/airbridge/templates/postgres-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "airbridge.fullname" . }}-postgres
+spec:
+  ports:
+  - port: {{ .Values.postgres.port }}
+    targetPort: {{ .Values.postgres.port }}
+  selector:
+    app: {{ include "airbridge.fullname" . }}-postgres

--- a/infra/helm/airbridge/templates/scheduler-deployment.yaml
+++ b/infra/helm/airbridge/templates/scheduler-deployment.yaml
@@ -32,6 +32,10 @@ spec:
         - name: EDGE_API_TOKEN_ID
           value: {{ .Values.edgeApi.tokenSecretId | quote }}
 {{- end }}
+        - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+          value: {{ printf "postgresql+psycopg2://%s:%s@%s-postgres:%d/%s" .Values.postgres.user .Values.postgres.password (include "airbridge.fullname" .) .Values.postgres.port .Values.postgres.db | quote }}
+        - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+          value: {{ printf "postgresql+psycopg2://%s:%s@%s-postgres:%d/%s" .Values.postgres.user .Values.postgres.password (include "airbridge.fullname" .) .Values.postgres.port .Values.postgres.db | quote }}
         livenessProbe:
           exec:
             command: ["bash", "-c", "airflow jobs check --job-type SchedulerJob"]

--- a/infra/helm/airbridge/templates/triggerer-deployment.yaml
+++ b/infra/helm/airbridge/templates/triggerer-deployment.yaml
@@ -32,6 +32,10 @@ spec:
         - name: EDGE_API_TOKEN_ID
           value: {{ .Values.edgeApi.tokenSecretId | quote }}
 {{- end }}
+        - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+          value: {{ printf "postgresql+psycopg2://%s:%s@%s-postgres:%d/%s" .Values.postgres.user .Values.postgres.password (include "airbridge.fullname" .) .Values.postgres.port .Values.postgres.db | quote }}
+        - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+          value: {{ printf "postgresql+psycopg2://%s:%s@%s-postgres:%d/%s" .Values.postgres.user .Values.postgres.password (include "airbridge.fullname" .) .Values.postgres.port .Values.postgres.db | quote }}
         livenessProbe:
           exec:
             command: ["bash", "-c", "airflow jobs check --job-type TriggererJob"]

--- a/infra/helm/airbridge/templates/webserver-deployment.yaml
+++ b/infra/helm/airbridge/templates/webserver-deployment.yaml
@@ -32,6 +32,10 @@ spec:
         - name: EDGE_API_TOKEN_ID
           value: {{ .Values.edgeApi.tokenSecretId | quote }}
 {{- end }}
+        - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
+          value: {{ printf "postgresql+psycopg2://%s:%s@%s-postgres:%d/%s" .Values.postgres.user .Values.postgres.password (include "airbridge.fullname" .) .Values.postgres.port .Values.postgres.db | quote }}
+        - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
+          value: {{ printf "postgresql+psycopg2://%s:%s@%s-postgres:%d/%s" .Values.postgres.user .Values.postgres.password (include "airbridge.fullname" .) .Values.postgres.port .Values.postgres.db | quote }}
         ports:
         - containerPort: {{ .Values.webserver.service.port }}
         livenessProbe:

--- a/infra/helm/airbridge/values-dev.yaml
+++ b/infra/helm/airbridge/values-dev.yaml
@@ -75,3 +75,12 @@ airflow:
   #   delete_local_logs = True
   #   [api_auth]
   #   jwt_secret = ${JWT_SECRET}
+
+postgres:
+  image: postgres
+  tag: "15"
+  pullPolicy: IfNotPresent
+  user: airflow
+  password: airflow
+  db: airflow
+  port: 5432

--- a/infra/helm/airbridge/values.yaml
+++ b/infra/helm/airbridge/values.yaml
@@ -150,3 +150,12 @@ dagSync:
   intervalSeconds: 60
   backoffLimit: 3
   retries: 5
+
+postgres:
+  image: postgres
+  tag: "15"
+  pullPolicy: IfNotPresent
+  user: airflow
+  password: airflow
+  db: airflow
+  port: 5432


### PR DESCRIPTION
## Summary
- deploy Postgres inside Airbridge Helm chart
- connect webserver, scheduler, and triggerer to shared Postgres instance
- load Postgres image and wait for database in minikube-up

## Testing
- `helm lint infra/helm/airbridge -f infra/helm/airbridge/values-dev.yaml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4a4d33c28832ca6a368eef7b5b7c7